### PR TITLE
feat: Implementa multiplos planos de treino

### DIFF
--- a/my_app/lib/models/workout_plan.dart
+++ b/my_app/lib/models/workout_plan.dart
@@ -1,0 +1,29 @@
+import 'exercise_model.dart';
+
+class WorkoutPlan {
+  String name;
+  List<Exercise> exercises;
+
+  WorkoutPlan({required this.name, required this.exercises});
+
+  // Métodos fromJson/toJson para que possamos salvá-lo
+  // no repositório de arquivos, assim como fizemos com o Exercise.
+
+  factory WorkoutPlan.fromJson(Map<String, dynamic> json) {
+    var exerciseList = json['exercises'] as List;
+    List<Exercise> exercises = exerciseList.map((e) => Exercise.fromJson(e)).toList();
+    
+    return WorkoutPlan(
+      name: json['name'] as String,
+      exercises: exercises,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+      // Converte cada Exercise em seu próprio map JSON
+      'exercises': exercises.map((e) => e.toJson()).toList(),
+    };
+  }
+}

--- a/my_app/lib/providers/workout_provider.dart
+++ b/my_app/lib/providers/workout_provider.dart
@@ -1,53 +1,84 @@
-// lib/providers/workout_provider.dart
 import 'package:flutter/foundation.dart';
 import '../models/exercise_model.dart';
+import '../models/workout_plan.dart'; // Importe o novo modelo
 import '../repositories/workout_repository.dart';
 
 class WorkoutProvider with ChangeNotifier {
   final WorkoutRepository _repository;
 
-  List<Exercise> _exercises = [];
+  List<WorkoutPlan> _plans = [];
   bool _isLoading = true;
 
-  List<Exercise> get exercises => _exercises;
+  List<WorkoutPlan> get plans => _plans;
   bool get isLoading => _isLoading;
 
   WorkoutProvider({WorkoutRepository? repository})
       : _repository = repository ?? const FileWorkoutRepository();
 
-  Future<void> loadExercises() async {
+  Future<void> loadPlans() async {
     _isLoading = true;
     notifyListeners();
-    _exercises = await _repository.loadExercises();
+    _plans = await _repository.loadWorkoutPlans();
     _isLoading = false;
     notifyListeners();
   }
 
-  // Salva e notifica
-  Future<void> _saveAndNotify() async {
-    await _repository.saveExercises(_exercises);
+  Future<void> _savePlansAndNotify() async {
+    await _repository.saveWorkoutPlans(_plans);
     notifyListeners();
   }
 
-  void addExercise() {
-    _exercises.add(
-      Exercise(name: 'Novo Exercício Adicionado', series: '3 séries de 12'),
+  // --- Métodos para gerenciar PLANOS ---
+
+  void addPlan(String name) {
+    _plans.add(
+      WorkoutPlan(name: name, exercises: []),
     );
-    // Salva em "segundo plano", mas notifica a UI imediatamente
-    _saveAndNotify();
+    _savePlansAndNotify();
   }
 
-  void updateExercise(int index, Exercise exercise) {
-    if (index >= 0 && index < _exercises.length) {
-      _exercises[index] = exercise;
-      _saveAndNotify();
+  void deletePlan(int planIndex) {
+    if (planIndex >= 0 && planIndex < _plans.length) {
+      _plans.removeAt(planIndex);
+      _savePlansAndNotify();
     }
   }
 
-  void deleteExercise(int index) {
-    if (index >= 0 && index < _exercises.length) {
-      _exercises.removeAt(index);
-      _saveAndNotify();
+  void updatePlanName(int planIndex, String newName) {
+    if (planIndex >= 0 && planIndex < _plans.length) {
+      _plans[planIndex].name = newName;
+      _savePlansAndNotify();
+    }
+  }
+
+  // --- Métodos para gerenciar EXERCÍCIOS DENTRO DE UM PLANO ---
+
+  void addExerciseToPlan(int planIndex) {
+    if (planIndex >= 0 && planIndex < _plans.length) {
+      _plans[planIndex].exercises.add(
+            Exercise(name: 'Novo Exercício', series: '3 séries de 10'),
+          );
+      _savePlansAndNotify();
+    }
+  }
+
+  void updateExerciseInPlan(int planIndex, int exerciseIndex, Exercise exercise) {
+    if (planIndex >= 0 && planIndex < _plans.length) {
+      final plan = _plans[planIndex];
+      if (exerciseIndex >= 0 && exerciseIndex < plan.exercises.length) {
+        plan.exercises[exerciseIndex] = exercise;
+        _savePlansAndNotify();
+      }
+    }
+  }
+
+  void deleteExerciseFromPlan(int planIndex, int exerciseIndex) {
+    if (planIndex >= 0 && planIndex < _plans.length) {
+      final plan = _plans[planIndex];
+      if (exerciseIndex >= 0 && exerciseIndex < plan.exercises.length) {
+        plan.exercises.removeAt(exerciseIndex);
+        _savePlansAndNotify();
+      }
     }
   }
 }

--- a/my_app/lib/repositories/workout_repository.dart
+++ b/my_app/lib/repositories/workout_repository.dart
@@ -1,64 +1,74 @@
 // repositories/workout_repository.dart
 import '../models/exercise_model.dart';
-
+import '../models/workout_plan.dart'; // Importe o novo modelo
 import 'dart:io';
 import 'dart:convert';
 import 'package:path_provider/path_provider.dart';
 
-
 abstract class WorkoutRepository {
-  /// Carrega a lista de exercícios.
-  Future<List<Exercise>> loadExercises();
+  /// Carrega a lista de PLANOS de exercícios.
+  Future<List<WorkoutPlan>> loadWorkoutPlans();
 
-  /// Salva a lista de exercícios.
-  Future<void> saveExercises(List<Exercise> exercises);
+  /// Salva a lista de PLANOS de exercícios.
+  Future<void> saveWorkoutPlans(List<WorkoutPlan> plans);
 }
 
-// repositories/workout_repository.dart (no mesmo arquivo)
-
-
 class FileWorkoutRepository implements WorkoutRepository {
-  
   const FileWorkoutRepository();
 
-  // A lógica de encontrar o arquivo foi movida para cá.
   Future<File> _getFile() async {
     final directory = await getApplicationDocumentsDirectory();
     final path = directory.path;
+    // O nome do arquivo pode continuar o mesmo, mas seu conteúdo será diferente
     return File('$path/workout.json');
   }
 
   @override
-  Future<List<Exercise>> loadExercises() async {
+  Future<List<WorkoutPlan>> loadWorkoutPlans() async {
     try {
       final file = await _getFile();
       if (await file.exists()) {
         final contents = await file.readAsString();
-        final List<dynamic> exercisesJson = jsonDecode(contents);
-        return exercisesJson.map((json) => Exercise.fromJson(json)).toList();
+        final List<dynamic> plansJson = jsonDecode(contents);
+        // Mapeia o JSON para a lista de WorkoutPlan
+        return plansJson.map((json) => WorkoutPlan.fromJson(json)).toList();
       } else {
-        // Retorna a lista padrão se o arquivo não existir.
+        // Retorna uma lista de planos padrão se o arquivo não existir.
         return [
-          Exercise(name: 'Supino Reto com Barra', series: '4 séries'),
-          Exercise(name: 'Supino Inclinado com Halteres', series: '4 séries'),
-          Exercise(name: 'Crucifixo na Máquina (Voador)', series: '3 séries'),
-          Exercise(name: 'Mergulho nas Paralelas (Dips)', series: '3 séries'),
-          Exercise(name: 'Tríceps na Polia Alta com Corda', series: '4 séries'),
-          Exercise(name: 'Tríceps Francês com Halter', series: '3 séries'),
+          WorkoutPlan(
+            name: 'Treino A: Peito e Tríceps',
+            exercises: [
+              Exercise(name: 'Supino Reto com Barra', series: '4 séries'),
+              Exercise(name: 'Supino Inclinado com Halteres', series: '4 séries'),
+              Exercise(name: 'Crucifixo na Máquina (Voador)', series: '3 séries'),
+              Exercise(name: 'Mergulho nas Paralelas (Dips)', series: '3 séries'),
+              Exercise(name: 'Tríceps na Polia Alta com Corda', series: '4 séries'),
+              Exercise(name: 'Tríceps Francês com Halter', series: '3 séries'),
+            ],
+          ),
+          WorkoutPlan(
+            name: 'Treino B: Costas e Bíceps',
+            exercises: [
+              Exercise(name: 'Barra Fixa', series: '4 séries'),
+              Exercise(name: 'Puxada Frontal', series: '4 séries'),
+              Exercise(name: 'Remada Curvada', series: '3 séries'),
+              Exercise(name: 'Rosca Direta', series: '4 séries'),
+            ],
+          ),
         ];
       }
     } catch (e) {
-      print("Erro ao carregar exercícios: $e");
-      // Retorna uma lista vazia em caso de erro.
+      print("Erro ao carregar planos de treino: $e");
       return [];
     }
   }
 
   @override
-  Future<void> saveExercises(List<Exercise> exercises) async {
+  Future<void> saveWorkoutPlans(List<WorkoutPlan> plans) async {
     final file = await _getFile();
-    final List<Map<String, dynamic>> exercisesJson =
-        exercises.map((exercise) => exercise.toJson()).toList();
-    await file.writeAsString(jsonEncode(exercisesJson));
+    // Converte a lista de planos para JSON
+    final List<Map<String, dynamic>> plansJson =
+        plans.map((plan) => plan.toJson()).toList();
+    await file.writeAsString(jsonEncode(plansJson));
   }
 }

--- a/my_app/lib/screens/training_page.dart
+++ b/my_app/lib/screens/training_page.dart
@@ -1,150 +1,95 @@
 import 'package:flutter/material.dart';
-import '../models/exercise_model.dart';
-import '../repositories/workout_repository.dart';
-import 'edit_exercise_page.dart';
+import 'package:provider/provider.dart';
+import '../providers/workout_provider.dart';
+import 'workout_plan_details_page.dart'; // Importe a nova tela de detalhes
 
 class TrainingPage extends StatefulWidget {
-  final WorkoutRepository repository;
-
-  const TrainingPage({
-    Key? key,
-    this.repository = const FileWorkoutRepository(),
-  }) : super(key: key);
+  const TrainingPage({Key? key}) : super(key: key);
 
   @override
   State<TrainingPage> createState() => TrainingPageState();
 }
 
 class TrainingPageState extends State<TrainingPage> {
-  List<Exercise> chestAndTricepsWorkout = [];
-  bool _isLoading = true;
-
   @override
   void initState() {
     super.initState();
-    loadExercises();
+    // Agora chama loadPlans() em vez de loadExercises()
+    Provider.of<WorkoutProvider>(context, listen: false).loadPlans();
   }
 
-  Future<void> loadExercises() async {
-    if (mounted) setState(() => _isLoading = true);
-    final loadedExercises = await widget.repository.loadExercises();
-    if (mounted) {
-      setState(() {
-        chestAndTricepsWorkout = loadedExercises;
-        _isLoading = false;
-      });
-    }
-  }
-
-  Future<void> saveChanges() async {
-    await widget.repository.saveExercises(chestAndTricepsWorkout);
-  }
-
-  void _addExercise() {
-    setState(() {
-      chestAndTricepsWorkout.add(
-        Exercise(name: 'Novo Exercício Adicionado', series: '3 séries de 12'),
-      );
-    });
-    saveChanges();
-  }
-
-  void _navigateToEditPage(BuildContext context, int index) async {
-    final result = await Navigator.push(
+  // Navega para a tela de detalhes passando o índice do plano
+  void _navigateToPlanDetails(int planIndex) {
+    Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (context) => EditExercisePage(
-          exercise: chestAndTricepsWorkout[index],
-        ),
+        builder: (context) => WorkoutPlanDetailsPage(planIndex: planIndex),
       ),
     );
+  }
 
-    bool shouldSave = false;
-
-    if (result == 'DELETE') {
-      setState(() {
-        chestAndTricepsWorkout.removeAt(index);
-      });
-      shouldSave = true;
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Exercício apagado com sucesso.'),
-            backgroundColor: Colors.red,
+  // Mostra um diálogo para adicionar um novo plano
+  void _showAddPlanDialog() {
+    final nameController = TextEditingController();
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Novo Plano de Treino'),
+          content: TextField(
+            controller: nameController,
+            decoration: const InputDecoration(labelText: 'Nome do Plano (ex: Treino C)'),
+            autofocus: true,
           ),
+          actions: [
+            TextButton(
+              child: const Text('Cancelar'),
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+            TextButton(
+              child: const Text('Adicionar'),
+              onPressed: () {
+                if (nameController.text.isNotEmpty) {
+                  context.read<WorkoutProvider>().addPlan(nameController.text);
+                  Navigator.of(context).pop();
+                }
+              },
+            ),
+          ],
         );
-      }
-    } else if (result != null && result is Exercise) {
-      setState(() {
-        chestAndTricepsWorkout[index] = result;
-      });
-      shouldSave = true;
-    }
-
-    if (shouldSave) {
-      saveChanges();
-    }
+      },
+    );
   }
 
   @override
   Widget build(BuildContext context) {
+    final workoutProvider = context.watch<WorkoutProvider>();
+
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Treino de Peito e Tríceps'),
-        backgroundColor: Colors.blueAccent,
-      ),
-      body: _isLoading
-          ? const Center(child: Text('Carregando exercícios...'))
-          : Column(
-              children: [
-                Expanded(
-                  child: ListView.builder(
-                    padding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
-                    itemCount: chestAndTricepsWorkout.length,
-                    itemBuilder: (BuildContext context, int index) {
-                      final exercise = chestAndTricepsWorkout[index];
-                      return Card(
-                        margin: const EdgeInsets.symmetric(
-                            horizontal: 10.0, vertical: 4.0),
-                        child: ListTile(
-                          contentPadding: const EdgeInsets.symmetric(
-                              vertical: 10.0, horizontal: 15.0),
-                          leading: CircleAvatar(
-                            backgroundColor: Colors.amber[100],
-                            child: Text('${index + 1}',
-                                style: const TextStyle(
-                                    fontWeight: FontWeight.bold,
-                                    color: Colors.black87)),
-                          ),
-                          title: Text(exercise.name,
-                              style:
-                                  const TextStyle(fontWeight: FontWeight.w500)),
-                          subtitle: Text(exercise.series),
-                          trailing: const Icon(Icons.edit),
-                          onTap: () => _navigateToEditPage(context, index),
-                        ),
-                      );
-                    },
+      // A AppBar foi movida para a tela de detalhes
+      body: workoutProvider.isLoading
+          ? const Center(child: Text('Carregando planos...'))
+          : ListView.builder(
+              padding: const EdgeInsets.all(8.0),
+              itemCount: workoutProvider.plans.length,
+              itemBuilder: (context, index) {
+                final plan = workoutProvider.plans[index];
+                return Card(
+                  child: ListTile(
+                    title: Text(plan.name, style: const TextStyle(fontWeight: FontWeight.bold)),
+                    subtitle: Text('${plan.exercises.length} exercícios'),
+                    trailing: const Icon(Icons.arrow_forward_ios),
+                    onTap: () => _navigateToPlanDetails(index),
                   ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: ElevatedButton.icon(
-                    onPressed: _addExercise,
-                    icon: const Icon(Icons.add),
-                    label: const Text('Adicionar Exercício'),
-                    style: ElevatedButton.styleFrom(
-                      minimumSize: const Size.fromHeight(50),
-                      backgroundColor: Colors.green,
-                      foregroundColor: Colors.white,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(10.0),
-                      ),
-                    ),
-                  ),
-                ),
-              ],
+                );
+              },
             ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _showAddPlanDialog,
+        child: const Icon(Icons.add),
+        tooltip: 'Adicionar Plano',
+        backgroundColor: Colors.amber,
+      ),
     );
   }
 }

--- a/my_app/lib/screens/workout_plan_details_page.dart
+++ b/my_app/lib/screens/workout_plan_details_page.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/exercise_model.dart';
+import '../providers/workout_provider.dart';
+import 'edit_exercise_page.dart';
+
+class WorkoutPlanDetailsPage extends StatefulWidget {
+  final int planIndex;
+
+  const WorkoutPlanDetailsPage({Key? key, required this.planIndex})
+      : super(key: key);
+
+  @override
+  _WorkoutPlanDetailsPageState createState() => _WorkoutPlanDetailsPageState();
+}
+
+class _WorkoutPlanDetailsPageState extends State<WorkoutPlanDetailsPage> {
+
+  void _addExercise() {
+    context.read<WorkoutProvider>().addExerciseToPlan(widget.planIndex);
+  }
+
+  void _navigateToEditPage(BuildContext context, int exerciseIndex) async {
+    final workoutProvider = context.read<WorkoutProvider>();
+    final exercise = workoutProvider.plans[widget.planIndex].exercises[exerciseIndex];
+
+    final result = await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => EditExercisePage(exercise: exercise),
+      ),
+    );
+
+    if (!mounted) return;
+
+    bool shouldShowSnackbar = false;
+
+    if (result == 'DELETE') {
+      workoutProvider.deleteExerciseFromPlan(widget.planIndex, exerciseIndex);
+      shouldShowSnackbar = true;
+    } else if (result != null && result is Exercise) {
+      workoutProvider.updateExerciseInPlan(widget.planIndex, exerciseIndex, result);
+    }
+
+    if (shouldShowSnackbar) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Exercício apagado com sucesso.'),
+          backgroundColor: Colors.red,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Assista o provider
+    final workoutProvider = context.watch<WorkoutProvider>();
+    // Pegue o plano específico pelo índice
+    final plan = workoutProvider.plans[widget.planIndex];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(plan.name), // Título da AppBar é o nome do plano
+        backgroundColor: Colors.blueAccent,
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView.builder(
+              padding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
+              itemCount: plan.exercises.length, // Lista os exercícios DESTE plano
+              itemBuilder: (BuildContext context, int index) {
+                final exercise = plan.exercises[index];
+                return Card(
+                  margin: const EdgeInsets.symmetric(
+                      horizontal: 10.0, vertical: 4.0),
+                  child: ListTile(
+                    contentPadding: const EdgeInsets.symmetric(
+                        vertical: 10.0, horizontal: 15.0),
+                    leading: CircleAvatar(
+                      backgroundColor: Colors.amber[100],
+                      child: Text('${index + 1}',
+                          style: const TextStyle(
+                              fontWeight: FontWeight.bold,
+                              color: Colors.black87)),
+                    ),
+                    title: Text(exercise.name,
+                        style: const TextStyle(fontWeight: FontWeight.w500)),
+                    subtitle: Text(exercise.series),
+                    trailing: const Icon(Icons.edit),
+                    onTap: () => _navigateToEditPage(context, index),
+                  ),
+                );
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: ElevatedButton.icon(
+              onPressed: _addExercise,
+              icon: const Icon(Icons.add),
+              label: const Text('Adicionar Exercício'),
+              style: ElevatedButton.styleFrom(
+                minimumSize: const Size.fromHeight(50),
+                backgroundColor: Colors.green,
+                foregroundColor: Colors.white,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10.0),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Esta funcionalidade substitui a lista única de exercícios por um sistema
de múltiplos planos de treino (ex: Treino A, B, C), cada um com sua
própria lista de exercícios.

Isso é uma mudança estrutural central para a proposta do app.

Alterações:
- Criado o modelo `WorkoutPlan` para agrupar um nome e uma `List<Exercise>`.
- `WorkoutRepository` foi atualizado para salvar e carregar uma `List<WorkoutPlan>` no arquivo JSON.
- `WorkoutProvider` agora gerencia uma `List<WorkoutPlan>` e contém
  métodos para CRUD de planos (ex: `addPlan`) e de exercícios
  *dentro* de um plano (ex: `addExerciseToPlan`).
- `TrainingPage` foi refatorada para ser uma lista de Planos de Treino.
- Criada a nova tela `WorkoutPlanDetailsPage` para exibir e gerenciar
  os exercícios de um plano específico (a antiga funcionalidade da
  `TrainingPage`).